### PR TITLE
Ajout endpoint /api/prixHoraires pour prix 24h glissantes

### DIFF
--- a/src/Entity/PrixHoraires.php
+++ b/src/Entity/PrixHoraires.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\PrixHorairesProvider;
+
+/**
+ * Représente les prix kWh pour les 24 prochaines heures glissantes.
+ * Compatible avec l'optimiseur de prix journalier Loxone.
+ */
+#[ApiResource(
+    paginationEnabled: false,
+    operations: [
+        new Get(
+            name: 'getPrixHoraires',
+            uriTemplate: 'prixHoraires',
+            provider: PrixHorairesProvider::class,
+            openapi: new Operation(
+                summary: "Retourne les prix kWh pour les 24 prochaines heures glissantes.",
+                description: "Cette méthode retourne un objet contenant les prix du kWh en euros TTC pour les 24 prochaines heures (H0 = heure actuelle, H23 = dans 23 heures).\n\nLa logique Tempo officielle est appliquée : le jour Tempo commence à 6h et se termine à 6h le lendemain.\n\nSi la couleur d'une heure n'est pas encore connue (typiquement pour les heures du lendemain après-midi), la valeur sera null.\n\nCliquez sur 'Try it out' pour expérimenter et obtenir le code correspondant."
+            )
+        ),
+    ]
+)]
+class PrixHoraires
+{
+    /**
+     * Tableau associatif des tarifs par heure (H0 à H23).
+     * H0 = heure actuelle, H23 = dans 23 heures.
+     * Chaque entrée contient codeCouleur, codeHoraire, tarifKwh et libTarif.
+     * Valeur = null si la couleur n'est pas connue.
+     * @var array<string, array{codeCouleur: int, codeHoraire: int, tarifKwh: float, libTarif: string}|null>
+     */
+    #[ApiProperty(
+        example: [
+            "H0" => ["codeCouleur" => 3, "codeHoraire" => 1, "tarifKwh" => 0.6468, "libTarif" => "Rouge-HP"],
+            "H1" => ["codeCouleur" => 3, "codeHoraire" => 1, "tarifKwh" => 0.6468, "libTarif" => "Rouge-HP"],
+            "H2" => ["codeCouleur" => 3, "codeHoraire" => 0, "tarifKwh" => 0.146, "libTarif" => "Rouge-HC"],
+            "H3" => null
+        ]
+    )]
+    private array $prix = [];
+
+    public function getPrix(): array
+    {
+        return $this->prix;
+    }
+
+    public function setPrix(array $prix): static
+    {
+        $this->prix = $prix;
+        return $this;
+    }
+
+    public function setHourData(int $hour, ?array $data): static
+    {
+        $this->prix["H$hour"] = $data;
+        return $this;
+    }
+}

--- a/src/State/PrixHorairesProvider.php
+++ b/src/State/PrixHorairesProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\PrixHoraires;
+use App\Repository\JourTempoRepository;
+use App\Repository\TarificationRepository;
+use DateTime;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Fournisseur de données pour les prix horaires sur 24h glissantes.
+ */
+class PrixHorairesProvider implements ProviderInterface
+{
+    public function __construct(
+        private TempsReelProvider $tempsReelProvider,
+        private JourTempoRepository $jourTempoRepository,
+        private TarificationRepository $tarificationRepository,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    public function provide(
+        Operation $operation,
+        array $uriVariables = [],
+        array $context = []
+    ): object|array|null {
+        // La donnée expire à chaque changement d'heure
+        $cacheKey = 'prixHoraires-' . date('Y-m-d H') . ':00:00';
+
+        // On vérifie si apcu_entry existe
+        if (function_exists('apcu_entry')) {
+            // Cache max 1h
+            return apcu_entry($cacheKey, [$this, 'getPrixHoraires'], 3610);
+        } else {
+            // Pas de cache, on calcule à chaque appel
+            return $this->getPrixHoraires($cacheKey);
+        }
+    }
+
+    private function getPrixHoraires(string $cacheKey): PrixHoraires
+    {
+        $this->logger->info("Calcul des prix horaires pour $cacheKey");
+
+        $prixHoraires = new PrixHoraires();
+        $tarif = $this->tarificationRepository->findOneBy([]);
+        $now = new DateTime();
+        $currentHour = (int) $now->format('G');
+
+        // Cache des jours Tempo pour éviter les requêtes multiples
+        $joursTempoCache = [];
+
+        for ($n = 0; $n < 24; $n++) {
+            // Calculer la date/heure cible
+            $targetDateTime = clone $now;
+            $targetDateTime->modify("+$n hour");
+            $targetHour = (int) $targetDateTime->format('G');
+
+            // Calculer le jour Tempo (règle des 6h)
+            $tempoDate = clone $targetDateTime;
+            if ($targetHour < 6) {
+                $tempoDate->modify('-1 day');
+            }
+            $tempoDateStr = $tempoDate->format('Y-m-d');
+
+            // Récupérer le jour Tempo (avec cache local)
+            if (!isset($joursTempoCache[$tempoDateStr])) {
+                $joursTempoCache[$tempoDateStr] = $this->jourTempoRepository->findOneBy(['dateJour' => $tempoDateStr]);
+            }
+            $jourTempo = $joursTempoCache[$tempoDateStr];
+
+            // Si pas de jour Tempo ou couleur inconnue → null
+            if ($jourTempo === null || $jourTempo->getCodeJour() === TARIF_INCONNU) {
+                $prixHoraires->setHourData($n, null);
+                continue;
+            }
+
+            // Utiliser TempsReelProvider pour calculer le tarif
+            $tr = $this->tempsReelProvider->getTempsReelForDateTime($targetDateTime, $jourTempo, $tarif);
+
+            $prixHoraires->setHourData($n, [
+                'codeCouleur' => $tr->getCodeCouleur(),
+                'codeHoraire' => $tr->getCodeHoraire(),
+                'tarifKwh' => $tr->getTarifKwh(),
+                'libTarif' => $tr->getLibTarif(),
+            ]);
+        }
+
+        return $prixHoraires;
+    }
+}


### PR DESCRIPTION
## Description

Nouvel endpoint qui retourne les prix kWh pour les **24 prochaines heures glissantes**, conçu pour l'intégration avec les systèmes domotiques.

## Motivation

Actuellement, pour calculer les prix horaires côté client, il faut :
1. Appeler `/api/jourTempo/today` et `/api/jourTempo/tomorrow`
2. Appeler `/api/tarifs`
3. Implémenter la logique Tempo (jour commence à 6h, HP/HC)

Ce nouvel endpoint centralise ce calcul côté serveur et simplifie l'intégration.

Ex : pour ma maison j'utilise Loxone. Dans Loxone Config cela obllige à faire un bloc écrit en Pico C. Autant donc que cette logique soit globalisée pour tout le monde et mise en cache. La communauté pourra alors s'en servir à souhait.

## Format de réponse

```json
{
  "prix": {
    "H0": 0.6468,
    "H1": 0.6468,
    "H12": 0.146,
    "H23": null
  }
}
